### PR TITLE
Add requesocks dependency

### DIFF
--- a/setupThug.sh
+++ b/setupThug.sh
@@ -57,6 +57,7 @@ pip install pydot2
 pip install python-magic
 pip install rarfile
 pip install pymongo
+pip install requesocks
 
 #Install Yara
 cd /opt


### PR DESCRIPTION
During initial install, requesocks causing thug to throw a trace, once install, help displayed properly.
